### PR TITLE
Display of inline attached images in email notification

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -11,3 +11,4 @@ Redmine::Plugin.register :redmine_image_clipboard_paste do
 end
 
 ActionMailer::Base.register_interceptor(InlineImagesEmailInterceptor)
+

--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,6 @@
 require 'redmine'
 require 'issue_hooks'
+require 'email_hooks'
 
 Redmine::Plugin.register :redmine_image_clipboard_paste do
   name 'Image Clipboard Paste'
@@ -8,3 +9,5 @@ Redmine::Plugin.register :redmine_image_clipboard_paste do
   version '1.0.0'
   requires_redmine :version_or_higher => '2.3.0'
 end
+
+ActionMailer::Base.register_interceptor(InlineImagesEmailInterceptor)

--- a/lib/email_hooks.rb
+++ b/lib/email_hooks.rb
@@ -1,0 +1,19 @@
+class InlineImagesEmailInterceptor
+  def self.delivering_email(message)
+    parts = message.body.parts
+    parts.each do |part|
+      if part.mime_type == "text/html"
+        part.body = part.body.to_s.gsub(/(<img src=")([^"]+)(")/) do
+          image_url = $2
+          attachment_url = image_url
+          attachment_object = Attachment.where(:filename => File.basename(image_url)).first
+          if attachment_object
+            message.attachments.inline[attachment_object.filename] = File.read(attachment_object.diskfile)
+            attachment_url = message.attachments[attachment_object.filename].url
+          end
+          $1 << attachment_url << $3
+        end
+      end
+    end
+  end
+end

--- a/lib/email_hooks.rb
+++ b/lib/email_hooks.rb
@@ -22,8 +22,9 @@ class InlineImagesEmailInterceptor
             attachment_object = Attachment.where(:filename => File.basename(image_url)).first
             if attachment_object
               # Use CIDs
-              message.attachments.inline[attachment_object.filename] = File.read(attachment_object.diskfile)
-              attachment_url = message.attachments[attachment_object.filename].url
+              image_name = "inline_image." << attachment_object.filename
+              message.attachments.inline[image_name] = File.read(attachment_object.diskfile)
+              attachment_url = message.attachments[image_name].url
 
               # Alternatively use Base64
               # attachment_url = "data:#{Redmine::MimeType.of(attachment_object.diskfile)};base64,#{Base64.encode64(open(attachment_object.diskfile) { |io| io.read })}"

--- a/lib/email_hooks.rb
+++ b/lib/email_hooks.rb
@@ -1,19 +1,41 @@
 class InlineImagesEmailInterceptor
   def self.delivering_email(message)
-    parts = message.body.parts
-    parts.each do |part|
+    has_images = false
+
+    message.body.parts.each do |part|
       if part.mime_type == "text/html"
-        part.body = part.body.to_s.gsub(/(<img src=")([^"]+)(")/) do
-          image_url = $2
-          attachment_url = image_url
-          attachment_object = Attachment.where(:filename => File.basename(image_url)).first
-          if attachment_object
-            message.attachments.inline[attachment_object.filename] = File.read(attachment_object.diskfile)
-            attachment_url = message.attachments[attachment_object.filename].url
+        has_images = part.body.to_s.include? "<img src="
+      end
+    end
+
+    if has_images
+      # Delete text part so we can use
+      # multipart/related content-type for message
+      message.body.parts.select! { |part| part.mime_type == 'text/html' }
+
+      message.body.parts.each do |part|
+        if part.mime_type == "text/html"
+          # search for <img> tags
+          part.body = part.body.to_s.gsub(/(<img src=")([^"]+)(")/) do
+            image_url = $2
+            attachment_url = image_url
+            attachment_object = Attachment.where(:filename => File.basename(image_url)).first
+            if attachment_object
+              # Use CIDs
+              message.attachments.inline[attachment_object.filename] = File.read(attachment_object.diskfile)
+              attachment_url = message.attachments[attachment_object.filename].url
+
+              # Alternatively use Base64
+              # attachment_url = "data:#{Redmine::MimeType.of(attachment_object.diskfile)};base64,#{Base64.encode64(open(attachment_object.diskfile) { |io| io.read })}"
+            end
+
+            $1 << attachment_url << $3
           end
-          $1 << attachment_url << $3
         end
       end
+
+      # Dirty hack for setting content-type to multipart/related
+      message.content_type = message.content_type.gsub(/(multipart\/)[^;]+(;)/, '\1related\2')
     end
   end
 end

--- a/lib/email_hooks.rb
+++ b/lib/email_hooks.rb
@@ -39,3 +39,4 @@ class InlineImagesEmailInterceptor
     end
   end
 end
+


### PR DESCRIPTION
A dirty solution for problem described in http://www.redmine.org/issues/2770. It's not always an option to allow access for attachments for anonymous users (email agents).

All inline images are prefixed with `inline_image.` so they could be filtered by Redmine using `Exclude attachments by name` parameter of `Incoming emails` preference pane. 
